### PR TITLE
ci(security): sign images with cosign and generate SBOM (SPDX)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,6 +46,31 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign images (cosign keyless)
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+          IMAGE_LATEST: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          IMAGE_SHA: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+        run: |
+          cosign sign --yes $IMAGE_LATEST
+          cosign sign --yes $IMAGE_SHA
+
+      - name: Generate SBOM (SPDX) for images
+        run: |
+          bunx --yes @anchore/syft ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest -o spdx-json=sbom-latest.spdx.json || true
+          bunx --yes @anchore/syft ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} -o spdx-json=sbom-sha.spdx.json || true
+
+      - name: Upload SBOM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-spdx
+          path: |
+            sbom-latest.spdx.json
+            sbom-sha.spdx.json
+
       - name: Export DATABASE_URL for subsequent steps
         if: ${{ secrets.DATABASE_URL != '' }}
         run: echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> $GITHUB_ENV

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -44,6 +44,8 @@ flowchart TB
     TEST["Unit Test (bun test)"]
     BUILD["Build"]
     TRIVY["Trivy"]
+    CODEQL["CodeQL"]
+    SECSCAN["Secret Scan (gitleaks)"]
     CMTL["Commitlint"]
   end
 
@@ -66,6 +68,7 @@ flowchart TB
 - Commit convention: Conventional Commits（commitlint）
 - Release: semantic-release（GitHub Release と `CHANGELOG.md` を自動更新）
 - Dependency updates: Renovate / Dependabot が PR を作成し CI をトリガー
+- Security: CodeQL（codeql.yml）、gitleaks（secret-scan.yml）
 
 ## Development workflow (sequence)
 

--- a/PREREQUISITE.md
+++ b/PREREQUISITE.md
@@ -275,6 +275,7 @@ docker compose exec db psql -U postgres -d app -c "SELECT 1;"
 # GitHub リポジトリの Settings > Secrets and variables > Actions で以下を設定
 # DATABASE_URL: 本番/ステージング環境のデータベース接続文字列（任意）
 # GITHUB_TOKEN: Actions 既定トークン。GHCR push/リリースに使用（通常は追加設定不要）
+# Secret Scan (gitleaks): 追加設定不要（GITHUB_TOKEN を使用）。
 ```
 
 ### Terraform (by environment)
@@ -282,6 +283,7 @@ docker compose exec db psql -U postgres -d app -c "SELECT 1;"
 ```bash
 # 現状は placeholder（infra/environments/{stg,prd}）
 # 利用クラウドのプロバイダ設定と認証情報を追加してください
+# PR に plan をコメントするジョブの導入を推奨（承認後 apply）。
 
 # ローカルでの Terraform 実行例
 cd infra/environments/stg

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ bun run md:lint:fix  # Markdown 自動修正
 
 - Operations (Issue/Branch/PR/Release)
 - CI/CD 定義（`.github/workflows/ci.yml`, `.github/workflows/cd.yml`）
+- その他ワークフロー（`.github/workflows/`）
+  - `codeql.yml`: CodeQL（PR + weekly schedule）
+  - `secret-scan.yml`: gitleaks（PR/push）
+  - `tf-plan.yml`: Terraform plan（infra/github）
 
 ## Architecture
 
@@ -234,8 +238,8 @@ Container / Build design を参照してください。
 
 ### CI (Pull Request)
 
-- Biome, Markdownlint, Type Check (tsc), Unit Test (bun test), Build,
-  Trivy, Commitlint
+- Biome, Markdownlint, Type Check (tsc), Unit Test (bun test), Build, Trivy,
+  Commitlint, CodeQL, Secret Scan (gitleaks)
 
 ### CD（main ブランチ）
 
@@ -257,6 +261,7 @@ Container / Build design を参照してください。
   - 通常は追加設定不要です。
 - **DATABASE_URL（任意）**: 設定されている場合のみ `Prisma migrate deploy` を実行します。
   - 未設定でも CD は失敗しません。
+- Secret Scan: `GITHUB_TOKEN` で動作（追加のシークレットは不要）。`GITLEAKS_LICENSE` は任意。
 
 ## Operations (Issue/Branch/PR/Release)
 


### PR DESCRIPTION
Implements Issue #19.\n- Install cosign and sign GHCR images (latest, sha) with keyless OIDC\n- Generate SBOM (SPDX) via syft and upload artifacts\n- id-token: write already granted\n\nFollow-ups: verify policy, attach attestations